### PR TITLE
Use UI scaling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,5 +59,6 @@ fn main() {
         .add_systems(Update, update_osd)
         .add_systems(Startup, spawn_help)
         .add_systems(Update, show_hide_help)
+        .add_systems(Update, scale_ui)
         .run();
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -35,6 +35,12 @@ pub fn text_section(color: Color, value: &str) -> TextSection {
     )
 }
 
+pub fn scale_ui(window: Query<&Window, With<PrimaryWindow>>, mut ui_scale: ResMut<UiScale>) {
+    let primary_window = window.single();
+    // the on-screen text was created on a 1440p screen so scale based off that
+    ui_scale.0 = primary_window.height() / 1440.;
+}
+
 pub fn spawn_help(mut commands: Commands) {
     commands
         .spawn((


### PR DESCRIPTION
On non-1440p screens the UI would go off the screen or be very small. This fixes that by adding a system to update the UI scale.